### PR TITLE
ZSH and dependency fix

### DIFF
--- a/control
+++ b/control
@@ -27,7 +27,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
  adduser,
  guile-2.0 (>= 2.0.7) | guile,
  libgcrypt20-dev,
-Recommends: guile-json, guile-gnutls
+Recommends: guile-json, guile-gnutls, nscd
 Description: Scheme based Functional Package Manager
  Guix is a functional package manager using Scheme
  for package definitions.

--- a/guix.install
+++ b/guix.install
@@ -24,4 +24,4 @@ usr/share/info/guix.info*
 usr/share/info/images/*.png
 usr/share/locale/*
 usr/share/man/man1/
-usr/share/zsh/site-functions/_guix usr/share/zsh/functions/Completion/Guix/_guix
+usr/share/zsh/site-functions/_guix usr/share/zsh/functions/Completion/


### PR DESCRIPTION
This ensures installation of the zsh auto-completion file in a location that actually gets searched.

Additionally 'nscd' now gets recommended because the [Guix documentation](https://www.gnu.org/software/guix/manual/guix.html#Name-Service-Switch-1) says:
> When using Guix on a foreign distro, we _strongly recommend_ that the system run the GNU C library’s _name service cache daemon_, `nscd`, which should be listening on the `/var/run/nscd/socket` socket.